### PR TITLE
fixed ASH_CFG_SYSTEM_QUERY_FILE env variable is ignored by ash_query

### DIFF
--- a/src/queries.l
+++ b/src/queries.l
@@ -155,6 +155,7 @@ void Queries::lazy_load() {
 
   // Load these files, in this order.
   query::files.push_back("/etc/ash/queries");
+  query::files.push_back(string(getenv("ASH_CFG_SYSTEM_QUERY_FILE")));
   query::files.push_back(string(getenv("HOME")) + "/.ash/queries");
 
   // Initialize the input file.


### PR DESCRIPTION
It wasn't possible to change the path to the system wide query file at runtime using ASH_CFG_SYSTEM_QUERY_FILE variable, because ash_query always looked considered only hardcoded /etc/ash/queires or $HOME/.ash/queries