### PR TITLE
initialize base class, avoid segfaults

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -76,7 +76,7 @@ string get_target(const Severity level) {
  * Constructs a logger and adds the severity to the output.
  */
 Logger::Logger(const Severity lvl)
-  : log(get_target(lvl).c_str(), fstream::out | fstream::app), level(lvl)
+  : ostream(NULL), log(get_target(lvl).c_str(), fstream::out | fstream::app), level(lvl)
 {
   char time_now[200];
   time_t t = time(NULL);


### PR DESCRIPTION
Without this change, both the log and query executables fail to run under most circumstances. On call to ios_base::~ios_base(), we got EXC_BAD_ACCESS.