### PR TITLE
Fix #11: Add a reference to ASH_CFG_SYSTEM_QUERY_FILE env var when loading queries

### DIFF
--- a/src/queries.cpp
+++ b/src/queries.cpp
@@ -741,6 +741,7 @@ void Queries::lazy_load() {
 
   // Load these files, in this order.
   query::files.push_back("/etc/ash/queries");
+  query::files.push_back(string(getenv("ASH_CFG_SYSTEM_QUERY_FILE")));
   query::files.push_back(string(getenv("HOME")) + "/.ash/queries");
 
   // Initialize the input file.


### PR DESCRIPTION
Without this, running `ash_query -Q` results in:
FAILED TO FIND A FILE TO PARSE!

This is because the C version of `get_query` is looking for queries in
`/etc/ash/queries` and `~/.ash/queries`, but not the default installation
path of `/user/local/etc/advanced-shell-history/queries`, which is
referenced in the `ASH_CFG_SYSTEM_QUERY_FILE` environment variable.

This commit adds the file referenced by this environment variable to the
list of queries files to load.

Fixes #11